### PR TITLE
Add uv instructions to README & fix issue with pipx instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ most Windows users.)
       <td><code>npm install -g rust-just</code></td>
     </tr>
     <tr>
-      <td><a href=https://pypi.org/>PyPI</a></td>
+      <td><a href=https://pipx.pypa.io/stable/>pipx</a></td>
       <td><a href=https://pypi.org/project/rust-just/>rust-just</a></td>
       <td><code>pipx install rust-just</code></td>
     </tr>
@@ -181,6 +181,11 @@ most Windows users.)
       <td><a href=https://snapcraft.io>Snap</a></td>
       <td><a href=https://snapcraft.io/just>just</a></td>
       <td><code>snap install --edge --classic just</code></td>
+    </tr>
+    <tr>
+      <td><a href=https://docs.astral.sh/uv/>uv</a></td>
+      <td><a href=https://pypi.org/project/rust-just/>rust-just</a></td>
+      <td><code>uv tool install rust-just</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Hi,

Given the increasing usage of uv over pipx/conda, I wanted to provide alternate instructions for uv users. In doing so I also changed the "Package Manager" section for the existing pipx entry to avoid confusing since both use PyPI as a directory.

Glad to make any desired changes & thank you for `just` and for providing a `rust-just` package on PyPI!